### PR TITLE
refactor: 하나의 특강에는 한명의 사용자만 신청 가능하게 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ fun applyForLecture(
 ### **`STEP 3`**
 - 서비스 수준의 동시성 테스트 : `LectureApplicationServiceConcurrencyTest`
 - 통합테스트 : `LectureFacadeTest`
+
+### **`STEP 4`**
+- 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선 => commitId :
+- 서비스 수준의 동시성 테스트 : `LectureApplicationServiceConcurrencyTest`
+- 통합테스트 : `LectureFacadeTest
+ 
+
+- 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증하는 **통합 테스트** 작성
+
 [ktlint]: https://github.com/JLLeitschuh/ktlint-gradle?tab=readme-ov-file#configuration
 
 [kotest]: https://kotest.io/docs/quickstart

--- a/README.md
+++ b/README.md
@@ -105,9 +105,19 @@ fun applyForLecture(
 - 통합테스트 : `LectureFacadeTest`
 
 ### **`STEP 4`**
-- 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선 => commitId :
+- 같은 사용자가 동일한 특강에 대해 신청 성공하지 못하도록 개선  
+    `lecture` 도메인에 특강을 신청했는지에 대한 여부를 확인 후 이미 해당 사용자가 신청한 특강이라면 exception을 발생하게하여 중복 신청 방지  
+    unique constraint를 사용한다면 db의존성이 생길 수 있기에 어플리케이션에서 해결.  
+```kotlin
+    fun hasUserApplied(user: User): Boolean {
+    lectureApplications.firstOrNull { it.participant.id == user.id }
+        ?: return false
+    throw LectureAlreadyAppliedException(user.id, id)
+} 
+```
+
 - 서비스 수준의 동시성 테스트 : `LectureApplicationServiceConcurrencyTest`
-- 통합테스트 : `LectureFacadeTest
+- 통합테스트 : `LectureFacadeTest`
  
 
 - 동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공하는 것을 검증하는 **통합 테스트** 작성

--- a/src/main/kotlin/io/hhplus/lectureapplyservice/application/service/LectureApplicationService.kt
+++ b/src/main/kotlin/io/hhplus/lectureapplyservice/application/service/LectureApplicationService.kt
@@ -29,6 +29,9 @@ class LectureApplicationService(
                 if (!lecture.hasCapacity()) {
                     return false
                 }
+                if (lecture.hasUserApplied(user)) {
+                    return false
+                }
 
                 val lectureApplication =
                     LectureApplication(

--- a/src/main/kotlin/io/hhplus/lectureapplyservice/domain/lecture/Lecture.kt
+++ b/src/main/kotlin/io/hhplus/lectureapplyservice/domain/lecture/Lecture.kt
@@ -1,7 +1,9 @@
 package io.hhplus.lectureapplyservice.domain.lecture
 
 import io.hhplus.lectureapplyservice.common.BaseEntity
+import io.hhplus.lectureapplyservice.domain.lecture.exception.LectureAlreadyAppliedException
 import io.hhplus.lectureapplyservice.domain.lecture.exception.LectureFullException
+import io.hhplus.lectureapplyservice.domain.user.User
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -49,5 +51,11 @@ class Lecture(
 
     fun getRemaining(): Int {
         return capacity - lectureApplications.size
+    }
+
+    fun hasUserApplied(user: User): Boolean {
+        lectureApplications.firstOrNull { it.participant.id == user.id }
+            ?: return false
+        throw LectureAlreadyAppliedException(user.id, id)
     }
 }

--- a/src/main/kotlin/io/hhplus/lectureapplyservice/domain/user/User.kt
+++ b/src/main/kotlin/io/hhplus/lectureapplyservice/domain/user/User.kt
@@ -20,6 +20,7 @@ class User(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("id")
     val id: Long = 0L,
+    // val id: Long? = null, // id를 nullable로 변경
     @Column(nullable = false, unique = true)
     @Comment("사용자 이름")
     val name: String,

--- a/src/test/kotlin/io/hhplus/lectureapplyservice/application/facade/LectureFacadeTest.kt
+++ b/src/test/kotlin/io/hhplus/lectureapplyservice/application/facade/LectureFacadeTest.kt
@@ -65,7 +65,7 @@ class LectureFacadeTest
                 for (i in 1..30) {
                     users.add(
                         User(
-                            id = i.toLong(),
+//                    id = i.toLong(),
                             name = "test$i",
                         ),
                     )
@@ -136,6 +136,41 @@ class LectureFacadeTest
                     }
                     then("30명만 성공한다.") {
                         successfulApplications.get() shouldBe 30
+                    }
+                }
+            }
+
+            given("동일한 유저가 같은 특강을 5번 신청하였을 때") {
+                val savedUser =
+                    userRepository.save(
+                        User(
+                            name = "test-user",
+                        ),
+                    )
+
+                val savedLecture =
+                    lectureRepository.save(
+                        Lecture(
+                            id = 1L,
+                            name = "lecture-1",
+                            lecturer = "lecturer-1",
+                            lectureDate = LocalDate.now(fixedClock),
+                        ),
+                    )
+
+                val successfulApplications = AtomicInteger(0)
+
+                `when`("수강신청을 진행하면") {
+                    runBlocking {
+                        (0..39).map {
+                            withContext(Dispatchers.IO) {
+                                val result = lectureFacade.applyForLecture(savedLecture.id, savedUser.id)
+                                if (result) successfulApplications.incrementAndGet()
+                            }
+                        }
+                    }
+                    then("1번만 성공한다.") {
+                        successfulApplications.get() shouldBe 1
                     }
                 }
             }

--- a/src/test/kotlin/io/hhplus/lectureapplyservice/application/service/LectureApplicationServiceConcurrencyTest.kt
+++ b/src/test/kotlin/io/hhplus/lectureapplyservice/application/service/LectureApplicationServiceConcurrencyTest.kt
@@ -36,7 +36,47 @@ class LectureApplicationServiceConcurrencyTest
                 userRepository.deleteAll()
             }
 
-            given("40명이 동시에 같은 강의에 요청하였을 때") {
+            given("서로 다른 40명이 동시에 같은 강의에 요청하였을 때") {
+                val lectureId = 1L
+                val savedLecture =
+                    lectureRepository.save(
+                        Lecture(
+                            id = lectureId,
+                            name = "test lecture",
+                            lecturer = "teacher",
+                            lectureDate = currentDate,
+                        ),
+                    )
+
+                val users = mutableListOf<User>()
+                for (i in 1..40) {
+                    users.add(
+                        User(
+                            name = "test$i",
+                        ),
+                    )
+                }
+
+                val savedUsers = userRepository.saveAll(users)
+                val successfulApplications = AtomicInteger(0)
+
+                `when`("applyForLecture를 호출될때") {
+                    runBlocking {
+                        (0..39).map { index ->
+                            withContext(Dispatchers.IO) {
+                                val result = lectureApplicationService.applyForLecture(savedLecture.id, savedUsers[index])
+                                if (result) successfulApplications.incrementAndGet()
+                            }
+                        }
+                    }
+                }
+
+                then("30명만 성공한다.") {
+                    successfulApplications.get() shouldBe 30
+                }
+            }
+
+            given("동일한 유저가 같은 특강을 5번 신청하였을 때") {
                 val lectureId = 1L
                 val savedLecture =
                     lectureRepository.save(
@@ -50,13 +90,16 @@ class LectureApplicationServiceConcurrencyTest
 
                 val savedUser =
                     userRepository.save(
-                        User(id = 1L, name = "Test User"),
+                        User(
+                            name = "test-user",
+                        ),
                     )
+
                 val successfulApplications = AtomicInteger(0)
 
                 `when`("applyForLecture를 호출될때") {
                     runBlocking {
-                        (1..40).map {
+                        (0..4).map {
                             withContext(Dispatchers.IO) {
                                 val result = lectureApplicationService.applyForLecture(savedLecture.id, savedUser)
                                 if (result) successfulApplications.incrementAndGet()
@@ -65,8 +108,8 @@ class LectureApplicationServiceConcurrencyTest
                     }
                 }
 
-                then("30명만 성공한다.") {
-                    successfulApplications.get() shouldBe 30
+                then("1번만 성공한다.") {
+                    successfulApplications.get() shouldBe 1
                 }
             }
         })

--- a/src/test/kotlin/io/hhplus/lectureapplyservice/domain/lecture/LectureTest.kt
+++ b/src/test/kotlin/io/hhplus/lectureapplyservice/domain/lecture/LectureTest.kt
@@ -1,6 +1,7 @@
 package io.hhplus.lectureapplyservice.domain.lecture
 
 import io.hhplus.lectureapplyservice.config.ClockConfig
+import io.hhplus.lectureapplyservice.domain.lecture.exception.LectureAlreadyAppliedException
 import io.hhplus.lectureapplyservice.domain.lecture.exception.LectureFullException
 import io.hhplus.lectureapplyservice.domain.user.User
 import io.kotest.assertions.throwables.shouldThrow
@@ -120,6 +121,36 @@ class LectureTest(
             val exception =
                 shouldThrow<LectureFullException> {
                     lecture.hasCapacity()
+                }
+        }
+
+        test("hasUserApplied는 사용자가 신청하지 않았을 경우 false를 리턴한다.") {
+            val user =
+                User(
+                    id = 1L,
+                    name = "User1",
+                )
+
+            lecture.hasUserApplied(user) shouldBe false
+        }
+
+        test("hasUserApplied는 사용자가 신청했을 경우 LectureAlreadyAppliedException을 발생시킨다.") {
+            val user =
+                User(
+                    id = 1L,
+                    name = "User1",
+                )
+
+            val application =
+                LectureApplication(
+                    lecture = lecture,
+                    participant = user,
+                )
+            (lecture.lectureApplications as MutableList).add(application)
+
+            val exception =
+                shouldThrow<LectureAlreadyAppliedException> {
+                    lecture.hasUserApplied(user)
                 }
         }
     })


### PR DESCRIPTION
## 작업내역
1. [하나의 특강에는 한명의 사용자만 신청 가능하게 변경](https://github.com/hhplus-backend/lecture-apply-service/commit/4718be8069a98ebac2ab726af101cfe0925e78db)

---
## 리뷰 포인트
1. 통합 테스트 구성이 잘 되어있는지 확인 부탁드립니다.
2. uniquekey를 사용하지 않았는데 비즈니스 로직으로만 핸들링 해도 되는지 궁금합니다.

<!--
예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.
-->

---
## KPT 회고

### keep
변경사항을 최소화 하게 코딩하려고 노력합니다.

### problem
글 작성을 하는 연습을 해야겠다...

### try


---
## 참고사항
